### PR TITLE
Add CLI version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ Taskgist requires a Google AI API key to interact with the Gemini LLM.
 
 Once installed and configured, you can use the `taskgist` CLI. Ensure your virtual environment is activated if you're not using `just run` or `uv run`.
 
+**Check the installed version:**
+```bash
+taskgist --version
+```
+
 **Basic usage with a string input:**
 ```bash
 taskgist "Create a new user authentication system with email verification and password reset capabilities"

--- a/src/taskgist/main.py
+++ b/src/taskgist/main.py
@@ -12,6 +12,7 @@ from baml_py.errors import BamlError
 from .baml_client.async_client import b as ab  # Using async client
 from .baml_client.types import KeywordPhrase
 from .baml_client.config import set_log_level
+from . import __version__
 
 # Load environment variables from .env file at the earliest opportunity
 load_dotenv()
@@ -126,6 +127,12 @@ def main_cli():
     parser = argparse.ArgumentParser(
         description="Generates a concise gist from a software engineering task description using BAML.",
         formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     parser.add_argument(
         "task",

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+import unittest
+
+import taskgist
+
+
+class TestVersionCLI(unittest.TestCase):
+    def test_cli_version(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "taskgist.main", "--version"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertTrue(result.stdout.strip().endswith(taskgist.__version__))
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support `taskgist --version` option using `argparse`
- document how to check the version in README
- add regression test for version output

## Testing
- `just lint`
- `uv run python -m unittest discover -s tests -v`