### PR TITLE
Improve keyword extraction instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ taskgist "Create a new user authentication system with email verification and pa
 ```
 Example output:
 ```
-create-user-authentication-email-verification
+create-user-authentication-email-verification-password-reset
 ```
 
 **Using a file input:**

--- a/src/taskgist/baml_src/keywords.baml
+++ b/src/taskgist/baml_src/keywords.baml
@@ -13,6 +13,7 @@ function ExtractKeywords(taskDescription: string) -> KeywordPhrase {
     - Omit articles (the, a, an), common prepositions (in, on, to, for), and pronouns (it, this, that, etc.).
     - Be representative of the core task.
     - Not exceed 5 words
+    - Each returned word must be a single token with no spaces
 
     {{ ctx.output_format }}
 


### PR DESCRIPTION
## Summary
- enforce single-word keywords in `keywords.baml`
- update README example to show full output

## Testing
- `just lint`
- `uv run python -m unittest discover -v -s tests`
- `just baml-generate`
